### PR TITLE
Run Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ build/
 .project
 .classpath
 
+run/
+
 # Project
 main/assets/sprites/
 

--- a/build.gradle
+++ b/build.gradle
@@ -115,8 +115,14 @@ allprojects{
 import arc.files.Fi
 import arc.util.OS
 
-tasks.register('install', DefaultTask) {
+import java.nio.channels.Channels
+import java.nio.channels.FileChannel
+import java.nio.channels.ReadableByteChannel
+final def yellow = "\u001B[33m";
+final def green = "\u001B[32m";
+final def white = "\u001B[0m";
 
+tasks.register('install', DefaultTask) {
     final def mainProj = project(':main')
     final def deployJarProvider = mainProj.tasks.named('deploy', Jar).flatMap { it.archiveFile }
     final def mindustryPathProp = project.providers.gradleProperty('mindustryPath')
@@ -133,9 +139,9 @@ tasks.register('install', DefaultTask) {
         def modsDir
 
         if (customPath && !customPath.trim().isEmpty()) {
-            modsDir = Fi.get(customPath)
+            modsDir = Fi.get(customPath).child("Mindustry").child("mods")
         } else {
-            modsDir = Fi.get(OS.getAppDataDirectoryString("Mindustry")).child("mods")
+            modsDir = Fi.get(OS.getAppDataDirectoryString("Mindustry"+archivesBaseName)).child("Mindustry").child("mods")
         }
 
         modsDir.mkdirs()
@@ -147,6 +153,86 @@ tasks.register('install', DefaultTask) {
 
         Fi.get(jarFile as String).copyTo(modsDir)
 
-        logger.lifecycle("Сopied '${jarFile.name}' to '${modsDir.path()}'.")
+        logger.lifecycle("- Сopied '${jarFile.name}' to '${modsDir.path()}'.")
+    }
+}
+
+tasks.register('installClient', DefaultTask) {
+    final def mindustryPathProp = project.providers.gradleProperty('mindustryPath')
+    final def mindustryVersionProp = project.providers.gradleProperty('mindustryVersion')
+
+    doLast {
+        String customPath = mindustryPathProp.getOrNull()
+        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(OS.getAppDataDirectoryString("Mindustry" + archivesBaseName))
+        String clientVersion = mindustryVersionProp.getOrElse("latest")
+        def clientFile = clientDir.child("client-${clientVersion}.jar")
+
+        if (clientFile.exists()) {
+            logger.lifecycle(yellow+"- Client is installed at '${clientFile.path()}'."+white)
+            return
+        }
+
+        clientDir.mkdirs()
+        clientFile.file().createNewFile();
+
+        String githubClientUrl = "https://github.com/Anuken/Mindustry/releases/download/${clientVersion}/Mindustry.jar"
+        logger.lifecycle(yellow+"> Downloading Mindustry ${clientVersion}..."+white)
+
+        URL url = new URL(githubClientUrl)
+        URLConnection connection = url.openConnection()
+        long contentLength = connection.contentLengthLong
+
+        InputStream input = connection.getInputStream()
+        FileOutputStream output = new FileOutputStream(clientFile.file())
+
+        byte[] buffer = new byte[8192]
+        long totalRead = 0
+        int bytesRead
+        int prevPercent = -1
+
+        while ((bytesRead = input.read(buffer)) != -1) {
+            output.write(buffer, 0, bytesRead)
+            totalRead += bytesRead
+
+            if (contentLength > 0) {
+                int percent = (int) ((totalRead * 100) / contentLength)
+                if (percent != prevPercent) {
+                    String bar = ('█' * (percent / 2)).padRight(50)
+                    String col = percent == 100 ? green : yellow;
+                    print "\r[${col}${bar}${white}] ${col}${percent}%${white}"
+                    System.out.flush()
+                    prevPercent = percent
+                }
+            }
+        }
+
+        input.close()
+        output.close()
+
+        logger.lifecycle("\n${white}- Installed to '${clientFile.path()}'.");
+    }
+}
+
+tasks.register('runClient', DefaultTask) {
+    dependsOn('installClient','install')
+    group = 'runs'
+    description = 'Deploys the mod to Mindustry and runs the client'
+
+    final def mindustryPathProp = project.providers.gradleProperty('mindustryPath')
+    final def mindustryVersionProp = project.providers.gradleProperty('mindustryVersion')
+
+    doLast {
+        String customPath = mindustryPathProp.getOrNull()
+        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(OS.getAppDataDirectoryString("Mindustry" + archivesBaseName))
+        String clientVersion = mindustryVersionProp.getOrElse("latest")
+        def clientFile = clientDir.child("client-${clientVersion}.jar")
+
+        logger.lifecycle(green + "> Starting Mindustry." + white);
+
+        exec {
+            environment "APPDATA", clientDir.absolutePath()
+            environment "DEVELOPMENT", "true"
+            commandLine 'java', '-jar', clientFile.path(), "-debug"
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -118,14 +118,12 @@ import arc.util.OS
 import java.nio.channels.Channels
 import java.nio.channels.FileChannel
 import java.nio.channels.ReadableByteChannel
-final def yellow = "\u001B[33m";
-final def green = "\u001B[32m";
-final def white = "\u001B[0m";
 
 tasks.register('install', DefaultTask) {
     final def mainProj = project(':main')
     final def deployJarProvider = mainProj.tasks.named('deploy', Jar).flatMap { it.archiveFile }
     final def mindustryPathProp = project.providers.gradleProperty('mindustryPath')
+    final def defaultMinPath = new File(project.projectDir,"run").getAbsolutePath();
 
     inputs.file(deployJarProvider)
             .withPathSensitivity(PathSensitivity.ABSOLUTE)
@@ -141,7 +139,7 @@ tasks.register('install', DefaultTask) {
         if (customPath && !customPath.trim().isEmpty()) {
             modsDir = Fi.get(customPath).child("mods")
         } else {
-            modsDir = Fi.get(OS.getAppDataDirectoryString("Mindustry"+archivesBaseName)).child("mods")
+            modsDir = Fi.get(defaultMinPath).child("mods")
         }
 
         modsDir.mkdirs()
@@ -153,22 +151,23 @@ tasks.register('install', DefaultTask) {
 
         Fi.get(jarFile as String).copyTo(modsDir)
 
-        logger.lifecycle("- Сopied '${jarFile.name}' to '${modsDir.path()}'.")
+        logger.lifecycle("Сopied '${jarFile.name}' to '${modsDir.path()}'.")
     }
 }
 
 tasks.register('installClient', DefaultTask) {
     final def mindustryPathProp = project.providers.gradleProperty('mindustryPath')
     final def mindustryVersionProp = project.providers.gradleProperty('mindustryVersion')
+    final def defaultMinPath = new File(project.projectDir,"run").getAbsolutePath();
 
     doLast {
         String customPath = mindustryPathProp.getOrNull()
-        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(OS.getAppDataDirectoryString("Mindustry" + archivesBaseName))
+        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(defaultMinPath)
         String clientVersion = mindustryVersionProp.getOrElse("latest")
         def clientFile = clientDir.child("client-${clientVersion}.jar")
 
         if (clientFile.exists()) {
-            logger.lifecycle(yellow+"- Client is installed at '${clientFile.path()}'."+white)
+            logger.lifecycle("Client is installed at '${clientFile.path()}'.")
             return
         }
 
@@ -176,7 +175,7 @@ tasks.register('installClient', DefaultTask) {
         clientFile.file().createNewFile();
 
         String githubClientUrl = "https://github.com/Anuken/Mindustry/releases/download/${clientVersion}/Mindustry.jar"
-        logger.lifecycle(yellow+"> Downloading Mindustry ${clientVersion}..."+white)
+        logger.lifecycle("> Downloading Mindustry ${clientVersion}...")
 
         URL url = new URL(githubClientUrl)
         URLConnection connection = url.openConnection()
@@ -198,8 +197,7 @@ tasks.register('installClient', DefaultTask) {
                 int percent = (int) ((totalRead * 100) / contentLength)
                 if (percent != prevPercent) {
                     String bar = ('█' * (percent / 2)).padRight(50)
-                    String col = percent == 100 ? green : yellow;
-                    print "\r[${col}${bar}${white}] ${col}${percent}%${white}"
+                    print "\r[${bar}] ${percent}%"
                     System.out.flush()
                     prevPercent = percent
                 }
@@ -209,7 +207,7 @@ tasks.register('installClient', DefaultTask) {
         input.close()
         output.close()
 
-        logger.lifecycle("\n${white}- Installed to '${clientFile.path()}'.");
+        logger.lifecycle("\nInstalled to '${clientFile.path()}'.");
     }
 }
 
@@ -220,14 +218,15 @@ tasks.register('runClient', DefaultTask) {
 
     final def mindustryPathProp = project.providers.gradleProperty('mindustryPath')
     final def mindustryVersionProp = project.providers.gradleProperty('mindustryVersion')
+    final def defaultMinPath = new File(project.projectDir,"run").getAbsolutePath();
 
     doLast {
         String customPath = mindustryPathProp.getOrNull()
-        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(OS.getAppDataDirectoryString("Mindustry" + archivesBaseName))
+        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(defaultMinPath)
         String clientVersion = mindustryVersionProp.getOrElse("latest")
         def clientFile = clientDir.child("client-${clientVersion}.jar")
 
-        logger.lifecycle(green + "> Starting Mindustry." + white);
+        logger.lifecycle("> Starting Mindustry.");
 
         exec {
             environment "MINDUSTRY_DATA_DIR", clientDir.absolutePath()

--- a/build.gradle
+++ b/build.gradle
@@ -134,14 +134,14 @@ tasks.register('install', DefaultTask) {
     doLast {
         File jarFile = deployJarProvider.get().asFile
         String customPath = mindustryPathProp.getOrNull()
-        def modsDir
 
-        if (customPath && !customPath.trim().isEmpty()) {
-            modsDir = Fi.get(customPath).child("mods")
-        } else {
-            modsDir = Fi.get(defaultMinPath).child("mods")
-        }
+        def mindustrySaves = customPath && !customPath.trim().isEmpty()
+                ? Fi.get(customPath)
+                : Fi.get(defaultMinPath)
+        def isSteam = mindustrySaves.child("Mindustry.exe").exists();
+        if(isSteam) mindustrySaves = mindustrySaves.child("saves")
 
+        def modsDir = mindustrySaves.child("mods")
         modsDir.mkdirs()
 
         File existingJar = modsDir.child(jarFile.name).file()
@@ -162,21 +162,27 @@ tasks.register('installClient', DefaultTask) {
 
     doLast {
         String customPath = mindustryPathProp.getOrNull()
-        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(defaultMinPath)
+        def mindustryPath = customPath && !customPath.trim().isEmpty()
+                ? Fi.get(customPath)
+                : Fi.get(defaultMinPath)
+        def isSteam = mindustryPath.child("Mindustry.exe").exists();
+        if(isSteam) {
+            logger.lifecycle("Mindustry is installed via Steam, skipping installation.")
+            return
+        }
+
         String clientVersion = mindustryVersionProp.getOrElse("latest")
-        def clientFile = clientDir.child("client-${clientVersion}.jar")
+        def clientFile = mindustryPath.child("client-${clientVersion}.jar")
 
         if (clientFile.exists()) {
             logger.lifecycle("Client is installed at '${clientFile.path()}'.")
             return
         }
 
-        clientDir.mkdirs()
+        mindustryPath.mkdirs()
         clientFile.file().createNewFile();
 
         String githubClientUrl = "https://github.com/Anuken/Mindustry/releases/download/${clientVersion}/Mindustry.jar"
-        logger.lifecycle("> Downloading Mindustry ${clientVersion}...")
-
         URL url = new URL(githubClientUrl)
         URLConnection connection = url.openConnection()
         long contentLength = connection.contentLengthLong
@@ -196,8 +202,7 @@ tasks.register('installClient', DefaultTask) {
             if (contentLength > 0) {
                 int percent = (int) ((totalRead * 100) / contentLength)
                 if (percent != prevPercent) {
-                    String bar = ('█' * (percent / 2)).padRight(50)
-                    print "\r[${bar}] ${percent}%"
+                    print "\r> Downloading Mindustry client: ${percent}%"
                     System.out.flush()
                     prevPercent = percent
                 }
@@ -222,16 +227,30 @@ tasks.register('runClient', DefaultTask) {
 
     doLast {
         String customPath = mindustryPathProp.getOrNull()
-        def clientDir = customPath?.trim() ? Fi.get(customPath) : Fi.get(defaultMinPath)
+        def mindustryPath = customPath && !customPath.trim().isEmpty()
+                ? Fi.get(customPath)
+                : Fi.get(defaultMinPath)
+        def isSteam = mindustryPath.child("Mindustry.exe").exists()
+        def mindustrySaves = mindustryPath
+        if(isSteam) mindustrySaves = mindustrySaves.child("saves")
+
         String clientVersion = mindustryVersionProp.getOrElse("latest")
-        def clientFile = clientDir.child("client-${clientVersion}.jar")
+        def clientFile = mindustryPath.child("client-${clientVersion}.jar")
+        if(isSteam) clientFile = mindustryPath.child("Mindustry.exe")
 
         logger.lifecycle("> Starting Mindustry.");
 
-        exec {
-            environment "MINDUSTRY_DATA_DIR", clientDir.absolutePath()
-            environment "DEVELOPMENT", "true"
-            commandLine 'java', '-jar', clientFile.path(), "-debug"
-        }
+        if(isSteam)
+            exec {
+                environment "MINDUSTRY_DATA_DIR", mindustrySaves.absolutePath()
+                environment "DEVELOPMENT", "true"
+                commandLine clientFile.path()
+            }
+        else
+            exec {
+                environment "MINDUSTRY_DATA_DIR", mindustrySaves.absolutePath()
+                environment "DEVELOPMENT", "true"
+                commandLine 'java', '-jar', clientFile.path(), "-debug"
+            }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -139,9 +139,9 @@ tasks.register('install', DefaultTask) {
         def modsDir
 
         if (customPath && !customPath.trim().isEmpty()) {
-            modsDir = Fi.get(customPath).child("Mindustry").child("mods")
+            modsDir = Fi.get(customPath).child("mods")
         } else {
-            modsDir = Fi.get(OS.getAppDataDirectoryString("Mindustry"+archivesBaseName)).child("Mindustry").child("mods")
+            modsDir = Fi.get(OS.getAppDataDirectoryString("Mindustry"+archivesBaseName)).child("mods")
         }
 
         modsDir.mkdirs()
@@ -230,7 +230,7 @@ tasks.register('runClient', DefaultTask) {
         logger.lifecycle(green + "> Starting Mindustry." + white);
 
         exec {
-            environment "APPDATA", clientDir.absolutePath()
+            environment "MINDUSTRY_DATA_DIR", clientDir.absolutePath()
             environment "DEVELOPMENT", "true"
             commandLine 'java', '-jar', clientFile.path(), "-debug"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ jabelVersion = 0.6.0
 # Leave empty to use 'displayName' value from mod.json
 classPrefix =
 # Root path for Mindustry client
-# Leave empty for using %APPDATA%/MindustryYourProjectName
+# Leave empty for using YourProjectFolder/run
 mindustryPath =
 # For faster compile time in next builds.
 org.gradle.daemon = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,8 @@ jabelVersion = 0.6.0
 # Mod prefix for generated classes (e.g., MyModSounds)
 # Leave empty to use 'displayName' value from mod.json
 classPrefix =
-# Root path for Mindustry client and Mindustry folder
+# Root path for Mindustry client
 # Leave empty for using %APPDATA%/MindustryYourProjectName
-# If you put %APPDATA%, the Mindustry folder will be %APPDATA%/Mindustry (default Mindustry folder)
 mindustryPath =
 # For faster compile time in next builds.
 org.gradle.daemon = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ jabelVersion = 0.6.0
 # Mod prefix for generated classes (e.g., MyModSounds)
 # Leave empty to use 'displayName' value from mod.json
 classPrefix =
-# Root path for Mindustry client
-# Leave empty for using YourProjectFolder/run
+# Root path for your Mindustry client (e.g., Steam or local installation)
+# Leave empty to use a standalone client inside this project
 mindustryPath =
 # For faster compile time in next builds.
 org.gradle.daemon = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ jabelVersion = 0.6.0
 # Mod prefix for generated classes (e.g., MyModSounds)
 # Leave empty to use 'displayName' value from mod.json
 classPrefix =
-# Custom mods path for 'install' task (e.g., Steam or portable Mindustry).
-# Leave empty for path auto-detection (e.g., %APPDATA%/Mindustry/mods).
+# Mindustry path for runClient
+# Leave empty for using %APPDATA%/MindustryYourProjectName
 mindustryPath =
 # For faster compile time in next builds.
 org.gradle.daemon = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,9 @@ jabelVersion = 0.6.0
 # Mod prefix for generated classes (e.g., MyModSounds)
 # Leave empty to use 'displayName' value from mod.json
 classPrefix =
-# Mindustry path for runClient
+# Root path for Mindustry client and Mindustry folder
 # Leave empty for using %APPDATA%/MindustryYourProjectName
+# If you put %APPDATA%, the Mindustry folder will be %APPDATA%/Mindustry (default Mindustry folder)
 mindustryPath =
 # For faster compile time in next builds.
 org.gradle.daemon = true


### PR DESCRIPTION
Adds 2 new tasks - installClient and runClient. 
installClient checks for a client jar in client folder, and if not found, installs it from MIndustry releases.
runClient uses existing 'install' and 'installClient' tasks, and then runs the client jar with modifiable mindustry root folder.

mindustryPath now specifies the client folder for mindustry, with default being APPDATA/MindustryProjectName.
So, for example - TemplateMod would be APPDATA/MindustryTemplateMod. in which will be the client jar and other mindustry stuff (saves,mods,etc.), essentially securing different projects messing up saves by sharing the same folder.